### PR TITLE
[BUGFIX] Use request instead of GeneralUtility::_GP for TYPO3 13

### DIFF
--- a/Classes/Service/MfaAuthenticationService.php
+++ b/Classes/Service/MfaAuthenticationService.php
@@ -47,7 +47,7 @@ class MfaAuthenticationService extends AuthenticationService
         if ((new Typo3Version())->getMajorVersion() >= 12) {
             /** @var ServerRequestInterface $request */
             $request = $this->authInfo['request'];
-            $otp = $request->getParsedBody()['mfa-frontend-otp'] ?? '';
+            $otp = $request->getParsedBody()['mfa-frontend-otp'] ?? $request->getQueryParams()['mfa-frontend-otp'] ?? '';
         } else {
             $otp = GeneralUtility::_GP('mfa-frontend-otp') ?? '';
         }

--- a/Classes/Service/MfaAuthenticationService.php
+++ b/Classes/Service/MfaAuthenticationService.php
@@ -21,6 +21,7 @@ use Causal\MfaFrontend\Traits\VerifyOtpTrait;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Authentication\AuthenticationService;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class MfaAuthenticationService extends AuthenticationService
@@ -43,9 +44,13 @@ class MfaAuthenticationService extends AuthenticationService
         }
 
         $secret = $mfa['totp']['secret'] ?? '';
-        /** @var ServerRequestInterface $request */
-        $request = $this->authInfo['request'];
-        $otp = $request->getParsedBody()['mfa-frontend-otp'] ?? '';
+        if ((new Typo3Version())->getMajorVersion() >= 12) {
+            /** @var ServerRequestInterface $request */
+            $request = $this->authInfo['request'];
+            $otp = $request->getParsedBody()['mfa-frontend-otp'] ?? '';
+        } else {
+            $otp = GeneralUtility::_GP('mfa-frontend-otp') ?? '';
+        }
 
         if ($this->verifyOneTimePassword($secret, $otp)) {
             // Store last usage of TOTP

--- a/Classes/Service/MfaAuthenticationService.php
+++ b/Classes/Service/MfaAuthenticationService.php
@@ -18,6 +18,7 @@ namespace Causal\MfaFrontend\Service;
 
 use Causal\MfaFrontend\Traits\MfaFieldTrait;
 use Causal\MfaFrontend\Traits\VerifyOtpTrait;
+use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Authentication\AuthenticationService;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -42,7 +43,9 @@ class MfaAuthenticationService extends AuthenticationService
         }
 
         $secret = $mfa['totp']['secret'] ?? '';
-        $otp = GeneralUtility::_GP('mfa-frontend-otp') ?? '';
+        /** @var ServerRequestInterface $request */
+        $request = $this->authInfo['request'];
+        $otp = $request->getParsedBody()['mfa-frontend-otp'] ?? '';
 
         if ($this->verifyOneTimePassword($secret, $otp)) {
             // Store last usage of TOTP


### PR DESCRIPTION
GeneralUtility::_GP was removed in TYPO3 13 and the request object has been added to the authInfo array since TYPO3 12