### PR TITLE
Fix reset on multiedit

### DIFF
--- a/Classes/Hook/DataHandler.php
+++ b/Classes/Hook/DataHandler.php
@@ -61,6 +61,10 @@ class DataHandler
             return;
         }
 
+        if (!isset($incomingFieldArray['tx_mfafrontend_enable'])) {
+            return;
+        }
+
         $preprocessFieldArrayDto = $this->getPreprocessFieldArrayDto(
             $incomingFieldArray,
             $table,


### PR DESCRIPTION
Fixes #4

It's possible to limit the editing of records to a subset of fields, which means the 'tx_mfafrontend_enable' field might not be available in the incomingFieldArray. In that case any update should just be completely skipped.