### PR TITLE
[BUGFIX] Prevent QR code regeneration after incorrect OTP entry

### DIFF
--- a/Classes/Controller/SetupController.php
+++ b/Classes/Controller/SetupController.php
@@ -150,6 +150,10 @@ class SetupController extends ActionController
                 $secretKey = $mfa['totp']['secret'] ?? '';
             }
 
+            if ($this->request->hasArgument(SetupForm::FORM_NAME)) {
+                $secretKey = $this->request->getArgument(SetupForm::FORM_NAME)['secret'] ?? null;
+            }
+
             $this->totpSecret = $this->secretFactory->create(
                 $this->getIssuer('fe_users'),
                 $this->getFrontendUser()['username'],


### PR DESCRIPTION
Fixes https://github.com/xperseguers/mfa_frontend/issues/9

The shared secret does not change after an invalid OTP attempt, so the QR code should remain unchanged as well. This fix ensures the QR code is not regenerated unnecessarily.